### PR TITLE
Hardcoded Soundex encode() to pad three zeros

### DIFF
--- a/books/modern_c++_with_tdd/mycode/c2/SoundexTest.cpp
+++ b/books/modern_c++_with_tdd/mycode/c2/SoundexTest.cpp
@@ -3,7 +3,7 @@
 class Soundex {
 
 public:
-  std::string encode(const std::string &word) const { return word; }
+  std::string encode(const std::string &word) const { return word + "000"; }
 };
 
 #include "gmock/gmock.h"
@@ -14,5 +14,5 @@ TEST(SoundexEncoding, RetainsSoleLetterOfOneLetterWord) {
 
   auto encoded = soundex.encode("C");
 
-  EXPECT_THAT(encoded, Eq("C"));
+  EXPECT_THAT(encoded, Eq("C000"));
 }


### PR DESCRIPTION
Hardcoded Soundex class encode() function to return word with three zeros
Updated TEST: RetainsSoleLetterOfOneLetterWord
Fixes #1