### PR TITLE
Added test: IgnoresVowelLikeLetters

### DIFF
--- a/books/modern_c++_with_tdd/mycode/c2/SoundexTest.cpp
+++ b/books/modern_c++_with_tdd/mycode/c2/SoundexTest.cpp
@@ -40,8 +40,12 @@ TEST_F(SoundexEncoding, ReplacesMultipleConsonantsWithDigits) {
 }
 
 /*
-* The return value from soundex.encode() must have length equal to 4
-*/
+ * The return value from soundex.encode() must have length equal to 4
+ */
 TEST_F(SoundexEncoding, LimitsLengthToFourCharacters) {
-   ASSERT_THAT(soundex.encode("Dcdlb").length(), Eq(4u)); 
+  ASSERT_THAT(soundex.encode("Dcdlb").length(), Eq(4u));
+}
+
+TEST_F(SoundexEncoding, IgnoresVowelLikeLetters) {
+  ASSERT_THAT(soundex.encode("Cwbarhl"), Eq("C164"));
 }


### PR DESCRIPTION
- Test passes, as encodedDigit() returns empty string "" for all vowel like letters
- Completes #10 